### PR TITLE
feat: Add k8s devshell

### DIFF
--- a/devshells/default.nix
+++ b/devshells/default.nix
@@ -7,4 +7,5 @@ let
 in
 nixpkgs.lib.genAttrs systems (system: {
   rust = import ./rust (inputs // { inherit system; });
+  k8s = import ./k8s (inputs // { inherit system; });
 })

--- a/devshells/k8s/default.nix
+++ b/devshells/k8s/default.nix
@@ -1,0 +1,17 @@
+{
+  system,
+  nixpkgs,
+  ...
+}@flake-inputs:
+let
+  pkgs = nixpkgs.legacyPackages.${system};
+in
+pkgs.mkShell {
+  packages =
+    with pkgs;
+    [
+      kubectl
+      kubelogin-oidc
+      kubetui
+    ];
+}

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1750920257,
-        "narHash": "sha256-DOBBWnbvOPYdTgf8LZQ3ZVkkXZ6wZYDYNe1MNclULww=",
+        "lastModified": 1751611255,
+        "narHash": "sha256-OoD7QdCBKk41sjGr7UpTxXtVba2kc2gfdex2qUCO1FQ=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "5bb38984af310c7922e33f88bcbc2dbd1ad3c736",
+        "rev": "e60617a7e9ad348c2679557d01177f9d244e6e5d",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749237914,
-        "narHash": "sha256-N5waoqWt8aMr/MykZjSErOokYH6rOsMMXu3UOVH5kiw=",
+        "lastModified": 1751479989,
+        "narHash": "sha256-M5KgdpVBVcW4HRVq9/OSRbrxlwsQ1ogEKqnvzsClDqU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "70c74b02eac46f4e4aa071e45a6189ce0f6d9265",
+        "rev": "34627c90f062da515ea358360f448da57769236e",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1750871759,
-        "narHash": "sha256-hMNZXMtlhfjQdu1F4Fa/UFiMoXdZag4cider2R9a648=",
+        "lastModified": 1751584117,
+        "narHash": "sha256-X+eVYBgJtR5WtFGifchtuidsl0epV3+oKXVxdd9ntuY=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "317542c1e4a3ec3467d21d1c25f6a43b80d83e7d",
+        "rev": "040049b79973a742bbd0eef25369b983f764dc38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
We will use oidc cluster login for all future clusters, and kubectl plugins like kubelogin-oidc are notoriously annoying to install as they rely on the krew plugin manager. With nix, it just works!