### PR TITLE
fix(osquery): Replace secret path type with path

### DIFF
--- a/modules/osquery.nix
+++ b/modules/osquery.nix
@@ -7,7 +7,7 @@
 {
   options = {
     famedly-hwp.osquery_secret_path = lib.mkOption {
-      type = lib.types.string;
+      type = lib.types.path;
       example = "/etc/secrets/osquery_secrets.txt";
       description = "Path to the osquery enroll secret";
     };


### PR DESCRIPTION
This gets rid of a deprecation warning, but also ensures that nobody tries to use a nix store path for this, as that would leak the secret.