### PR TITLE
feat: Add a module that lets you easily set up Cachix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a flake containing a collection of outputs required for
 developing with nix.
 
 Among these:
+
 - A basic system configuration module to conform with our ISMS on NixOS
 - A devshell for Rust development at Famedly
 
@@ -88,7 +89,36 @@ drivestrike:
 ```
 
 ##### Required files
+
 The enroll secret of osquery is expected to be found in `famedly-hwp.osquery_secret_path`, which you should set in your own config.
+
+### Cachix
+
+A pre-configured module is provided to use the Famedly Cachix instance.
+To use it, your system configuration should contain:
+
+```nix
+# configuration.nix
+{ flake-inputs, ... }:
+{
+  imports = [ flake-inputs.famedly-nixos.nixosModules.default ];
+
+  famedly-cachix.enable = true;
+  nix.extraOptions = ''
+    netrc-file = /etc/nix/netrc
+  '';
+}
+```
+
+The `netrc-file`, here in `/etc/nix/netrc`, should have at least the following contents:
+
+```
+machine famedly.cachix.org password <AUTH_TOKEN>
+```
+
+where an `<AUTH_TOKEN>` can be generated on the Cachix website. If you actually work
+here, you should be able to go to https://app.cachix.org/personal-auth-tokens
+and login with GitHub to generate an auth token.
 
 ## Maintenance & contributing
 

--- a/modules/cachix.nix
+++ b/modules/cachix.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  options.famedly-cachix = {
+    enable = lib.mkEnableOption "Famedly Cachix Module";
+  };
+  config = lib.mkIf config.famedly-cachix.enable {
+    nix.settings.substituters = [
+      "https://cache.nixos.org"
+      "https://famedly-oss.cachix.org"
+      "https://famedly.cachix.org"
+    ];
+    nix.settings.trusted-public-keys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "famedly-oss.cachix.org-1:WdEnFSvKeI7CRgbEDkgzd8LgtkzfxOT8t274YIGvTE4="
+      "famedly.cachix.org-1:eJntK6EfNdeiHeOY9QwR4gzUkNCp/l1F8N052vplx/I="
+    ];
+  };
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -20,6 +20,7 @@ flake-inputs: {
         ./clamav.nix
         ./osquery.nix
         ./git.nix
+        ./cachix.nix
       ];
       systemd.packages = [ drivestrike' ];
       systemd.services.drivestrike.enable = true;


### PR DESCRIPTION
I have grown tired of compiling. This module, along with instructions,
should make it easy for everyone to set up their laptop to connect to
Cachix, and use the binary cache generated by the CI.
