### PR TITLE
bump(drivestrike): Bump rpm hash

### DIFF
--- a/packages/drivestrike.nix
+++ b/packages/drivestrike.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.1.23-12";
   src = fetchurl {
     url = "https://app.drivestrike.com/static/yum/drivestrike.rpm";
-    sha256 = "sha256-wZ/0uD/mdJvPS+bASjwg9g79ZG+oSdwXXbyxb5rXyeo=";
+    sha256 = "sha256-kTYssDk+LkLWV9NLN/vrn+H/M2PsJm84bz59SrjBKlM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Looks like drivestrike made a sneaky version update without changing numbers.

I don't know if we *should* apply this change, there's no announcement. It's quite possible this is a supply chain attack. But then, I have absolutely zero trust in the security of drivestrike's stack anyway.

Maybe we should petition to remove the drivestrike requirement altogether until we migrate? It very much feels like we're installing malware by company policy.