### PR TITLE
docs: Update nixos version in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Famedly's ISMS policies.
 # flake.nix
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     famedly-nixos.url = "github:famedly/famedly-nixos";
   };
 


### PR DESCRIPTION
It was pointing people towards a version of Nixpkgs which hasn't received security updates since December last year.

This is bad.