### PR TITLE
docs: Use github protocol instead of git+ssh for famedly-nixos input

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Famedly's ISMS policies.
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
-    famedly-nixos.url = "git+ssh://git@github.com/famedly/famedly-nixos";
+    famedly-nixos.url = "github:famedly/famedly-nixos";
   };
 
   outputs =


### PR DESCRIPTION
Using `git+ssh` was necessary before this repository was made public, but now it's just inconvenient.